### PR TITLE
feat: Update prologCheckers js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -268,6 +268,16 @@ const prologCheckers = {
   svg(line) {
     return this.xml(line);
   },
+
+  /**
+   * Check that given line is the `JS` line.
+   *
+   * @param {string} line The line to check.
+   * @return {boolean} `true` if given is an JS `#!`, `false` otherwise.
+   */
+  js(line) {
+    return _.startsWith(line, '#!');
+  },
 };
 
 /**


### PR DESCRIPTION
Node file js startwith 

`#!/usr/bin/env <executableName>`

I update prolog checkers js case

```
  /**
   * Check that given line is the `JS` line.
   *
   * @param {string} line The line to check.
   * @return {boolean} `true` if given is an JS `#!`, `false` otherwise.
   */
  js(line) {
    return _.startsWith(line, '#!');
  },
```


Reference: [https://stackoverflow.com/questions/33509816/what-exactly-does-usr-bin-env-node-do-at-the-beginning-of-node-files](url)